### PR TITLE
AL - Change phases of Node steps so frontend builds before copy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,9 @@
 				<version>3.0.0</version>
 				<executions>
 					<execution>
-						<phase>generate-resources</phase>
+						<phase>process-resources</phase>
 						<configuration>
-							<target combine.children="append">
+							<target>
 								<mkdir dir="${project.basedir}/javascript/build" />
 								<copy todir="${project.build.directory}/classes/public">
 									<fileset dir="${project.basedir}/javascript/build" />
@@ -336,6 +336,7 @@
 						</configuration>
 						<executions>
 							<execution>
+								<phase>generate-resources</phase>
 								<id>install node and npm</id>
 								<goals>
 									<goal>install-node-and-npm</goal>


### PR DESCRIPTION
This PR addresses the missing frontend on Heroku deployments by altering the phases of `frontend-maven-plugin` and `maven-antrun-plugin` such that they will run in that order. To make this happen, we also remove the `combine.children` attribute that allows `maven-antrun-plugin` to combine copy steps.