### PR TITLE
eo/bz - removed API token column from Maintain Admins page

### DIFF
--- a/javascript/src/main/pages/Admin/Admin.js
+++ b/javascript/src/main/pages/Admin/Admin.js
@@ -54,7 +54,6 @@ const Admin = () => {
             <th>Last Name</th>
             <th>Role</th>
             <th>Change Role</th>
-            <th>Google API Search Token</th>
           </tr>
         </thead>
         <tbody>
@@ -83,7 +82,6 @@ const Admin = () => {
                       }>{buttonText}</Button>
                     }
                   </td>
-                  <td>{user.apiToken}</td>
                 </tr>
               );
             })


### PR DESCRIPTION
In this PR we remove the API token column from the Maintain Admins page. UI looks correct when testing locally. 