### PR TITLE
s21-7pm-1 - sc/sk - changed heading on Analyze Slack Data/Analyze Reactions

### DIFF
--- a/javascript/src/main/components/ChannelMessageReaction/MessageTableReaction.js
+++ b/javascript/src/main/components/ChannelMessageReaction/MessageTableReaction.js
@@ -11,7 +11,7 @@ export default ({ messages=[],reaction }) => {
     }
     const columns = [{
         dataField: 'user',
-        text: 'User'
+        text: 'Message Author'
     },{
         dataField: 'text',
         text: 'Contents'


### PR DESCRIPTION
In this PR, we changed the heading from "User" to "Message Author" on the Analyze Slack Data/Analyze Reactions page. 