### PR TITLE
7pm-3 md and bl - Search bars on slack search

### DIFF
--- a/javascript/src/main/components/ChannelMessages/MessageListView.js
+++ b/javascript/src/main/components/ChannelMessages/MessageListView.js
@@ -63,7 +63,7 @@ function timeUserFormatter(value, row) {
     return value + "-" + row.ts;
 }
 
-export default ({ messages }) => {
+export default ({ messages, searchField=true }) => {
     const { getAccessTokenSilently: getToken } = useAuth0();
     const {data: slackUsers} = useSWR([`/api/slackUsers`, getToken], fetchWithToken);
     
@@ -108,7 +108,7 @@ export default ({ messages }) => {
                 {
                     props => (
                         <div>
-                            <SearchBar { ...props.searchProps } />
+                            { searchField ? <SearchBar { ...props.searchProps } /> : null }
                             <hr />
                             <BootstrapTable { ...props.baseProps } />
                         </div>

--- a/javascript/src/main/pages/Messages/SearchResults.js
+++ b/javascript/src/main/pages/Messages/SearchResults.js
@@ -21,7 +21,7 @@ const SearchPage = () => {
                     <Form.Control type="text" placeholder="Enter Search String" />
                 </Form.Group>
             </Form>
-            <MessageListView messages = {searchResults || []} />
+            <MessageListView messages={searchResults || []} searchField={false} />
         </>
     );
 };

--- a/javascript/src/stories/components/ChannelMessages/MessageListView.stories.js
+++ b/javascript/src/stories/components/ChannelMessages/MessageListView.stories.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import MessageListView from "main/components/ChannelMessages/MessageListView";
+
+
+export default {
+  title: 'components/ChannelMessages/MessageListView',
+  component: MessageListView
+};
+
+const Template = (args) => <MessageListView {...args}/>;
+
+export const List = Template.bind({});
+
+List.args = {
+  messages: [{
+    "type": "message",
+    "subtype": "channel_join",
+    "ts": "1594143066.000200",
+    "user": "U017218J9B3",
+    "text": "<@U017218J9B3> has joined the channel",
+    "channel": "section-6pm",
+    "user_profile": {
+      "real_name": "Test Person"
+    }
+  },
+  {
+    "type": "message",
+    "subtype": "channel_join",
+    "ts": "1594143066.000200",
+    "user": "U017218J9B3",
+    "text": "Office hours at <https://ucsb.zoom.us/j/89220034995?pwd=VTlHNXJpTVgrSEs5QUtlMDdqMC9wQT09>",
+    "channel": "section-6pm",
+    "user_profile": {
+      "real_name": "Test Person"
+    }
+  }],
+}

--- a/javascript/src/stories/components/ChannelMessages/MessageListView.stories.js
+++ b/javascript/src/stories/components/ChannelMessages/MessageListView.stories.js
@@ -10,9 +10,8 @@ export default {
 
 const Template = (args) => <MessageListView {...args}/>;
 
-export const List = Template.bind({});
-
-List.args = {
+export const WithSearchBar = Template.bind({});
+WithSearchBar.args = {
   messages: [{
     "type": "message",
     "subtype": "channel_join",
@@ -35,4 +34,10 @@ List.args = {
       "real_name": "Test Person"
     }
   }],
-}
+};
+
+export const NoSearchBar = Template.bind({});
+NoSearchBar.args = {
+    searchField: false,
+    ...WithSearchBar.args
+};

--- a/javascript/src/test/components/ChannelMessages/MessageList.test.js
+++ b/javascript/src/test/components/ChannelMessages/MessageList.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { getAllByPlaceholderText, queryByPlaceholderText, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import MessageListView from "main/components/ChannelMessages/MessageListView";
 import useSWR from "swr";
 jest.mock("swr");

--- a/javascript/src/test/components/ChannelMessages/MessageList.test.js
+++ b/javascript/src/test/components/ChannelMessages/MessageList.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { getAllByPlaceholderText, queryByPlaceholderText, render } from "@testing-library/react";
 import MessageListView from "main/components/ChannelMessages/MessageListView";
 import useSWR from "swr";
 jest.mock("swr");
@@ -12,9 +12,27 @@ describe("MessageListView tests", () => {
 
     test("renders without crashing", () => {
         useSWR.mockReturnValue({
-            data:  []
+            data: []
         });
         render(<MessageListView messages={[]} />);
+    });
+
+    test("Search bar exists by default", () => {
+        useSWR.mockReturnValue({
+            data: []
+        });
+        const {queryByText} = render(<MessageListView messages={[]}/>);
+        const searchBar = queryByText(/Search/);
+        expect(searchBar).not.toBeNull();
+    });
+
+    test("Search bar removed with searchField prop", () => {
+        useSWR.mockReturnValue({
+            data: []
+        });
+        const {queryByText} = render(<MessageListView messages={[]} searchField={false}/>);
+        const searchBar = queryByText(/Search/);
+        expect(searchBar).toBeNull();
     });
 
     test("Displays username", () => {


### PR DESCRIPTION
In this PR, we add a `searchField` property to the `MessageListView` component and set it to false on the Slack Search page to remove the confusing double search bar. The default is true so any other pages will continue to display it. Additionally added tests and storybook stories for true and false values of `searchField`. Closes #220 