### PR TITLE
7pm-3 md - Add swagger-ui/index.html and api/docs endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,19 @@
 			<version>2.2.5.RELEASE</version>
 		  </dependency>
 
+		<!-- https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api -->
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/edu/ucsb/mapache/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/mapache/config/SecurityConfig.java
@@ -16,8 +16,13 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
 
   @Override
   public void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests().mvcMatchers("/api/public/**").permitAll().mvcMatchers("/api/**").authenticated().anyRequest()
-        .permitAll();
+    http.authorizeRequests()
+    .mvcMatchers("/**").permitAll()
+    .mvcMatchers("/api/public/**").permitAll()
+    .mvcMatchers("/swagger-ui/**").permitAll()
+    .mvcMatchers("/api/docs").permitAll()
+    .mvcMatchers("/api/**")
+    .authenticated().anyRequest().permitAll();
   }
 
   @Override

--- a/src/main/java/edu/ucsb/mapache/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/mapache/config/SpringFoxConfig.java
@@ -3,7 +3,6 @@ package edu.ucsb.mapache.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-// import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;

--- a/src/main/java/edu/ucsb/mapache/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/mapache/config/SpringFoxConfig.java
@@ -1,0 +1,30 @@
+package edu.ucsb.courses.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+
+/**
+ * Configuration for Swagger, a package that provides documentation
+ * for REST API endpoints.
+ * @see <a href="https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
+ */
+
+@Configuration
+public class SpringFoxConfig {                                    
+    @Bean
+    public Docket api() { 
+        return new Docket(DocumentationType.SWAGGER_2)
+          .select()              
+          .apis(RequestHandlerSelectors.any())    
+          .paths(regex("/api/.*"))                      
+          .build();                                           
+    }
+}

--- a/src/main/java/edu/ucsb/mapache/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/mapache/config/SpringFoxConfig.java
@@ -1,4 +1,4 @@
-package edu.ucsb.courses.config;
+package edu.ucsb.mapache.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/edu/ucsb/mapache/controllers/ReactController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/ReactController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class ReactController {
-  @RequestMapping(value = { "/", "/{x:[\\w\\-]+}", "/{x:^(?!api$).*$}/**/{y:[\\w\\-]+}" })
+  @RequestMapping(value = {"/", "/{x:^(?!swagger-ui$)[\\w\\-]+}", "/{x:^(?!api$).*$}/**/{y:[\\w\\-]+}"})
   public String getIndex() {
     return "/index.html";
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
+management.endpoints.web.exposure.include=mappings
+springfox.documentation.swagger.v2.path=/api/docs
 app.member.hosted-domain=ucsb.edu
-
 spring.config.location=classpath:/
 @environment-properties@


### PR DESCRIPTION
In this PR, we add the `swagger-ui/index.html` endpoint for API documentation and testing with a UI, and we add the JSON endpoint `api/docs`, following the implementation described in the [courses-search pull request](https://github.com/ucsb-cs156-s21/proj-ucsb-courses-search/pull/224).

Authenticated endpoints require a token. One can be obtained if and only if you are already logged in, by copying from the developer tools after making a request within the app, then pasting into the Authentication field on the swagger-ui page.

Annotations for additional documentation of endpoints can be added in the future.
Closes #257 