### PR TITLE
7pm 1 mapache slack messages

### DIFF
--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -31,7 +31,8 @@ import edu.ucsb.mapache.services.GoogleSearchServiceHelper;
 import edu.ucsb.mapache.services.NowService;
 import edu.ucsb.mapache.services.TeamEmailListService;  
 
-import edu.ucsb.mapache.documents.Message;
+import edu.ucsb.mapache.documents.Message;  
+import edu.ucsb.mapache.documents.SlackUserProfile;
 
 import java.io.IOException;
 import java.util.ArrayList;    

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -197,7 +197,7 @@ public class SlackSlashCommandController {
         String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName()); 
         List<Message> messageList = messageRepository.findByChannel(params.getChannelName());       
         for(int i = 0; i< messageList.size(); i++){  
-            message = message.concat(messageList.get(i).getTs()+" "+messageList.get(i).getUser_profile().getDisplay_name() + ": " + messageList.get(i).getText() +"\n");
+            message = message.concat(messageList.get(i).getTs()+" "+messageList.get(i).getUser() + ": " + messageList.get(i).getText() +"\n");
         } 
         RichMessage richMessage = new RichMessage(message); 
         richMessage.setResponseType("ephemeral");  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -203,7 +203,7 @@ public class SlackSlashCommandController {
         HashSet <String> channelMessages = new HashSet<String>();     
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName(), Sort.by(Sort.Direction.ASC, "ts"));       
         for(Message slackMessage : messageList){  
-            channelMessages.add(slackMessage.getUser_profile().getDisplay_name() + ": " + slackMessage.getText() +"\n");
+            channelMessages.add(slackMessage.getUser_profile().getName() + ": " + slackMessage.getText() +"\n");
         }   
         List<String> channelMessageList = new ArrayList<String>(channelMessages); 
         for (String output: channelMessageList){  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -194,7 +194,7 @@ public class SlackSlashCommandController {
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
         
         String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName()); 
-        List<Message> messageList = messageRepository.findByChannel(params.getChannelId());     
+        List<Message> messageList = messageRepository.findByChannel(params.getChannelName());     
         for(int i = 0; i< messageList.size(); i++){  
             message = message.concat(messageList.get(i).getUser() + ": " + messageList.get(i).getText() +"\n");
         } 

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -152,7 +152,7 @@ public class SlackSlashCommandController {
             return getTeamEmail(params);
         }   
 
-        if (firstArg.equals("search") && textParts[1].equals("slack") && textParts[2].equals("string")) { 
+        if (firstArg.equals("search") && textParts[1].equals("slack")) { 
             return getPreviousSlackMessages(params);  
         }
 
@@ -195,9 +195,15 @@ public class SlackSlashCommandController {
     }  
 
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
-        String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName());   
+        String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName());     
+        String[] textParts = params.getTextParts(); 
+        String searchString = "";     
+        for(int i = 2; i < textParts.length; i++){   
+            if (i != 2) {searchString += " ";}
+            searchString += textParts[i];
+        }
         HashSet <String> channelMessages = new HashSet<String>(); 
-        List<Message> messageList = messageRepository.findByChannel(params.getChannelName());       
+        List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName());       
         for(Message slackMessage : messageList){  
             channelMessages.add(slackMessage.getTs()+" "+slackMessage.getUser() + ": " + slackMessage.getText() +"\n");
         }   

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -206,16 +206,14 @@ public class SlackSlashCommandController {
         String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length));  
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName(), Sort.by(Sort.Direction.ASC, "ts"));       
         LinkedHashSet <String> channelMessages = new LinkedHashSet<String>();    
-        List<String> channelMessageList = new ArrayList<String>(); 
         for(Message slackMessage : messageList){           
             List<SlackUser> slackUser = slackuserRepository.findByID(slackMessage.getUser());  
             String newMessage = slackUser.get(0).getReal_name() + ": " + slackMessage.getText() +"\n";   
             if(!channelMessages.contains(newMessage)){    
                 channelMessages.add(newMessage); 
-                channelMessageList.add(newMessage);
             }  
         }   
-        for (String output: channelMessageList){  
+        for (String output: channelMessages){  
             message = message.concat(output); 
         }
         RichMessage richMessage = new RichMessage(message); 

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -39,7 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.auth0.jwt.JWT;
-import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.DecodedJWT;  
+import java.util.Arrays; 
 import java.util.HashMap;    
 import java.util.HashSet;   
 import java.util.Collections; 
@@ -195,13 +196,9 @@ public class SlackSlashCommandController {
     }  
 
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
-        String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName());     
+        String message = String.format("Displaying all previous messages that match input in %s:\n", params.getChannelName());     
         String[] textParts = params.getTextParts(); 
-        String searchString = "";     
-        for(int i = 2; i < textParts.length; i++){   
-            if (i != 2) {searchString += " ";}
-            searchString += textParts[i];
-        }
+        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length-1)); 
         HashSet <String> channelMessages = new HashSet<String>(); 
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName());       
         for(Message slackMessage : messageList){  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -15,7 +15,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestController;  
+import org.springframework.data.domain.Sort; 
 
 import edu.ucsb.mapache.models.SlackSlashCommandParams;
 import edu.ucsb.mapache.repositories.ChannelRepository;  
@@ -198,15 +199,13 @@ public class SlackSlashCommandController {
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
         String message = String.format("Displaying all previous messages that match input in %s:\n", params.getChannelName());     
         String[] textParts = params.getTextParts(); 
-        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length));   
-        message += searchString; 
-        HashSet <String> channelMessages = new HashSet<String>(); 
-        List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName());       
+        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length)); 
+        HashSet <String> channelMessages = new HashSet<String>();     
+        List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName(), Sort.by(Sort.Direction.ASC, "ts"));       
         for(Message slackMessage : messageList){  
-            channelMessages.add(slackMessage.getTs()+" "+slackMessage.getUser() + ": " + slackMessage.getText() +"\n");
+            channelMessages.add(slackMessage.getUser_profile().getDisplay_name() + ": " + slackMessage.getText() +"\n");
         }   
         List<String> channelMessageList = new ArrayList<String>(channelMessages); 
-        Collections.sort(channelMessageList); 
         for (String output: channelMessageList){  
             message = message.concat(output); 
         }

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -194,9 +194,9 @@ public class SlackSlashCommandController {
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
         
         String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName()); 
-        List<Message> messageList = messageRepository.findByChannel(params.getChannelName());     
+        List<Message> messageList = messageRepository.findByChannel(params.getChannelName());       
         for(int i = 0; i< messageList.size(); i++){  
-            message = message.concat(messageList.get(i).getUser() + ": " + messageList.get(i).getText() +"\n");
+            message = message.concat(messageList.get(i).getTs()+" "+messageList.get(i).getUser_profile().getDisplay_name() + ": " + messageList.get(i).getText() +"\n");
         } 
         RichMessage richMessage = new RichMessage(message); 
         richMessage.setResponseType("ephemeral");  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -40,7 +40,9 @@ import java.util.List;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import java.util.HashMap;  
+import java.util.HashMap;    
+import java.util.HashSet;   
+import java.util.Collections; 
 
 import edu.ucsb.mapache.models.SearchParameters;
 
@@ -193,21 +195,23 @@ public class SlackSlashCommandController {
     }  
 
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
-        
-        String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName()); 
+        String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName());   
+        HashSet <String> channelMessages = new HashSet<String>(); 
         List<Message> messageList = messageRepository.findByChannel(params.getChannelName());       
-        for(int i = 0; i< messageList.size(); i++){  
-            message = message.concat(messageList.get(i).getTs()+" "+messageList.get(i).getUser() + ": " + messageList.get(i).getText() +"\n");
-        } 
+        for(Message slackMessage : messageList){  
+            channelMessages.add(slackMessage.getTs()+" "+slackMessage.getUser() + ": " + slackMessage.getText() +"\n");
+        }   
+        List<String> channelMessageList = new ArrayList<String>(channelMessages); 
+        Collections.sort(channelMessageList); 
+        for (String output: channelMessageList){  
+            message = message.concat(output); 
+        }
         RichMessage richMessage = new RichMessage(message); 
         richMessage.setResponseType("ephemeral");  
 
         return richMessage.encodedMessage();
-
     }
-
-    
-    
+  
     public RichMessage googleSearch(SlackSlashCommandParams params) { // google search
         
         

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -44,7 +44,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;  
 import java.util.Arrays; 
 import java.util.HashMap;    
-import java.util.HashSet;   
+import java.util.LinkedHashSet;   
 import java.util.Collections; 
 
 import edu.ucsb.mapache.models.SearchParameters;
@@ -203,14 +203,18 @@ public class SlackSlashCommandController {
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
         String message = String.format("Displaying all previous messages that match input in %s:\n", params.getChannelName());     
         String[] textParts = params.getTextParts(); 
-        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length)); 
-        HashSet <String> channelMessages = new HashSet<String>();     
+        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length));  
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName(), Sort.by(Sort.Direction.ASC, "ts"));       
+        LinkedHashSet <String> channelMessages = new LinkedHashSet<String>();    
+        List<String> channelMessageList = new ArrayList<String>(); 
         for(Message slackMessage : messageList){           
-            List<SlackUser> slackUser = slackuserRepository.findByID(slackMessage.getUser()); 
-            channelMessages.add(slackUser.get(0).getReal_name() + ": " + slackMessage.getText() +"\n");
+            List<SlackUser> slackUser = slackuserRepository.findByID(slackMessage.getUser());  
+            String newMessage = slackUser.get(0).getReal_name() + ": " + slackMessage.getText() +"\n";   
+            if(!channelMessages.contains(newMessage)){    
+                channelMessages.add(newMessage); 
+                channelMessageList.add(newMessage);
+            }  
         }   
-        List<String> channelMessageList = new ArrayList<String>(channelMessages); 
         for (String output: channelMessageList){  
             message = message.concat(output); 
         }

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -198,7 +198,8 @@ public class SlackSlashCommandController {
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
         String message = String.format("Displaying all previous messages that match input in %s:\n", params.getChannelName());     
         String[] textParts = params.getTextParts(); 
-        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length-1)); 
+        String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length));   
+        message += searchString; 
         HashSet <String> channelMessages = new HashSet<String>(); 
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName());       
         for(Message slackMessage : messageList){  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -203,7 +203,7 @@ public class SlackSlashCommandController {
         HashSet <String> channelMessages = new HashSet<String>();     
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName(), Sort.by(Sort.Direction.ASC, "ts"));       
         for(Message slackMessage : messageList){  
-            channelMessages.add(slackMessage.getUser_profile().getName() + ": " + slackMessage.getText() +"\n");
+            channelMessages.add(slackMessage.getUser_profile() + ": " + slackMessage.getText() +"\n");
         }   
         List<String> channelMessageList = new ArrayList<String>(channelMessages); 
         for (String output: channelMessageList){  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -20,7 +20,8 @@ import org.springframework.data.domain.Sort;
 
 import edu.ucsb.mapache.models.SlackSlashCommandParams;
 import edu.ucsb.mapache.repositories.ChannelRepository;  
-import edu.ucsb.mapache.repositories.MessageRepository;
+import edu.ucsb.mapache.repositories.MessageRepository;   
+import edu.ucsb.mapache.repositories.SlackUserRepository;
 import edu.ucsb.mapache.entities.Student;
 import edu.ucsb.mapache.google.Item;
 import edu.ucsb.mapache.google.SearchResult;
@@ -33,7 +34,7 @@ import edu.ucsb.mapache.services.NowService;
 import edu.ucsb.mapache.services.TeamEmailListService;  
 
 import edu.ucsb.mapache.documents.Message;  
-import edu.ucsb.mapache.documents.SlackUserProfile;
+import edu.ucsb.mapache.documents.SlackUser;
 
 import java.io.IOException;
 import java.util.ArrayList;    
@@ -63,7 +64,10 @@ public class SlackSlashCommandController {
     ChannelRepository channelRepository; 
 
     @Autowired  
-    MessageRepository messageRepository; 
+    MessageRepository messageRepository;   
+
+    @Autowired 
+    SlackUserRepository slackuserRepository; 
 
     @Autowired
     GoogleSearchServiceHelper googleSearchServiceHelper;
@@ -202,8 +206,9 @@ public class SlackSlashCommandController {
         String searchString = String.join(" ",Arrays.copyOfRange(textParts,2,textParts.length)); 
         HashSet <String> channelMessages = new HashSet<String>();     
         List<Message> messageList = messageRepository.findByTextInChannel("\"" + searchString + "\"", params.getChannelName(), Sort.by(Sort.Direction.ASC, "ts"));       
-        for(Message slackMessage : messageList){  
-            channelMessages.add(slackMessage.getUser_profile() + ": " + slackMessage.getText() +"\n");
+        for(Message slackMessage : messageList){           
+            List<SlackUser> slackUser = slackuserRepository.findByID(slackMessage.getUser()); 
+            channelMessages.add(slackUser.get(0).getReal_name() + ": " + slackMessage.getText() +"\n");
         }   
         List<String> channelMessageList = new ArrayList<String>(channelMessages); 
         for (String output: channelMessageList){  

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -194,7 +194,7 @@ public class SlackSlashCommandController {
     public RichMessage getPreviousSlackMessages(SlackSlashCommandParams params){  
         
         String message = String.format("Displaying all previous messages in %s:\n", params.getChannelName()); 
-        List<Message> messageList = messageRepository.findByChannel(params.getChannelName());     
+        List<Message> messageList = messageRepository.findByChannel(params.getChannelId());     
         for(int i = 0; i< messageList.size(); i++){  
             message = message.concat(messageList.get(i).getUser() + ": " + messageList.get(i).getText() +"\n");
         } 

--- a/src/main/java/edu/ucsb/mapache/repositories/MessageRepository.java
+++ b/src/main/java/edu/ucsb/mapache/repositories/MessageRepository.java
@@ -21,6 +21,9 @@ public interface MessageRepository extends MongoRepository<Message, ObjectId> {
     List<Message> findByText(String searchString);
 
     @Query("{'reactions': {'$elemMatch': {'name' : ?0} }}")
-    List<Message> findByReactionName(String emojiSymbol);
+    List<Message> findByReactionName(String emojiSymbol);  
+
+    @Query("{$text: { $search: ?0}, 'channel': ?1}")
+    List<Message> findByTextInChannel(String searchString, String searchChannel);  
 }
 

--- a/src/main/java/edu/ucsb/mapache/repositories/MessageRepository.java
+++ b/src/main/java/edu/ucsb/mapache/repositories/MessageRepository.java
@@ -6,7 +6,8 @@ import edu.ucsb.mapache.entities.AppUser;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Repository;  
+import org.springframework.data.domain.Sort; 
 import java.util.List;
 
 @Repository
@@ -24,6 +25,6 @@ public interface MessageRepository extends MongoRepository<Message, ObjectId> {
     List<Message> findByReactionName(String emojiSymbol);  
 
     @Query("{$text: { $search: ?0}, 'channel': ?1}")
-    List<Message> findByTextInChannel(String searchString, String searchChannel);  
+    List<Message> findByTextInChannel(String searchString, String searchChannel, Sort sort);  
 }
 

--- a/src/main/java/edu/ucsb/mapache/repositories/SlackUserRepository.java
+++ b/src/main/java/edu/ucsb/mapache/repositories/SlackUserRepository.java
@@ -11,5 +11,8 @@ import java.util.Optional;
 @Repository
 public interface SlackUserRepository extends MongoRepository<SlackUser, ObjectId> {
     @Query("{ 'profile.email': ?0}")
-    List<SlackUser> findByEmail(String email);
+    List<SlackUser> findByEmail(String email);   
+    
+    @Query("{ 'id': ?0}")
+    List<SlackUser> findByID(String id);
 }

--- a/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
+++ b/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
@@ -271,6 +271,26 @@ public class SlackSlashCommandControllerTests {
                 .param("channel_name", "value").param("user_id", "value").param("user_name", "value")
                 .param("command", "/mapache").param("text", "teamlist").param("response_url", "value"))
                 .andExpect(status().is(200));
+    }   
+    
+    @Test 
+    public void test_slackSearchCommand() throws Exception {  
+      mockMvc.perform(post(testURL).contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("token", slackSlashCommandController.getSlackToken())
+                .param("team_id", "value").param("team_domain", "value").param("channel_id", "value")
+                .param("channel_name", "value").param("user_id", "value").param("user_name", "value")
+                .param("command", "/mapache").param("text", "search slack").param("response_url", "value"))
+                .andExpect(status().is(200));
+    }   
+
+    @Test 
+    public void test_slackSearchCommandMultipleArguments() throws Exception {  
+      mockMvc.perform(post(testURL).contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("token", slackSlashCommandController.getSlackToken())
+                .param("team_id", "value").param("team_domain", "value").param("channel_id", "value")
+                .param("channel_name", "value").param("user_id", "value").param("user_name", "value")
+                .param("command", "/mapache").param("text", "search slack computer").param("response_url", "value"))
+                .andExpect(status().is(200));
     }
 
 }

--- a/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
+++ b/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import edu.ucsb.mapache.config.SecurityConfig;
 import edu.ucsb.mapache.models.SlackSlashCommandParams;
 import edu.ucsb.mapache.repositories.ChannelRepository;
+import edu.ucsb.mapache.repositories.MessageRepository;
 
 import org.springframework.http.MediaType;
 
@@ -43,7 +44,10 @@ public class SlackSlashCommandControllerTests {
     SlackSlashCommandController slackSlashCommandController;
 
     @MockBean
-    NowService nowService;
+    NowService nowService;  
+
+    @MockBean 
+    MessageRepository messageRepository; 
 
     @MockBean
     ChannelRepository channelRepository;

--- a/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
+++ b/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
@@ -16,7 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import edu.ucsb.mapache.config.SecurityConfig;
 import edu.ucsb.mapache.models.SlackSlashCommandParams;
 import edu.ucsb.mapache.repositories.ChannelRepository;
-import edu.ucsb.mapache.repositories.MessageRepository;
+import edu.ucsb.mapache.repositories.MessageRepository;  
+import edu.ucsb.mapache.repositories.SlackUserRepository; 
 
 import org.springframework.http.MediaType;
 
@@ -50,7 +51,10 @@ public class SlackSlashCommandControllerTests {
     MessageRepository messageRepository; 
 
     @MockBean
-    ChannelRepository channelRepository;
+    ChannelRepository channelRepository;  
+
+    @MockBean 
+    SlackUserRepository slackuserRepository; 
 
     @MockBean
     GoogleSearchServiceHelper googleSearchServiceHelper;


### PR DESCRIPTION
running `/mapache` search slack <string> will return all the messages in sequential order from the channel it was called in. 

example output in our general channel:  for `/mapache search slack computer `
  **Displaying all previous messages that match input in general:
  Sebastian Anvari: What is up my Computer Scientists
  Andrew Lu: Computer Engineering majors:**   

works for multi line arguments, and codecov is at 98 percent. 