### PR TITLE
7pm-4 nw - Slack admins are also app admins by default

### DIFF
--- a/src/main/java/edu/ucsb/mapache/repositories/SlackUserRepository.java
+++ b/src/main/java/edu/ucsb/mapache/repositories/SlackUserRepository.java
@@ -13,6 +13,6 @@ public interface SlackUserRepository extends MongoRepository<SlackUser, ObjectId
     @Query("{ 'profile.email': ?0}")
     List<SlackUser> findByEmail(String email);
 
-    @Query("{ 'is_admin': true, 'profile.email': ?0")
+    @Query("{ 'is_admin': true, 'profile.email': ?0}")
     List<SlackUser> findAdminByEmail(String email);
 }

--- a/src/main/java/edu/ucsb/mapache/repositories/SlackUserRepository.java
+++ b/src/main/java/edu/ucsb/mapache/repositories/SlackUserRepository.java
@@ -12,4 +12,7 @@ import java.util.Optional;
 public interface SlackUserRepository extends MongoRepository<SlackUser, ObjectId> {
     @Query("{ 'profile.email': ?0}")
     List<SlackUser> findByEmail(String email);
+
+    @Query("{ 'is_admin': true, 'profile.email': ?0")
+    List<SlackUser> findAdminByEmail(String email);
 }


### PR DESCRIPTION
This PR makes it so Slack admins are also app admins by default (i.e. on first log-in). 

More specifically, if a new app user shares the email of some Slack admin in the linked Slack workspace, then the user's role is Admin.

Note this user is _not_ a permanent admin; they can be demoted and promoted, but they just start off as an admin.

### To-do
I am not an admin in the `ucsb-cs156-s21` Slack workspace, so I need someone who is an admin in that workspace to do a manual end-to-end test for this. Basically, a Slack admin who has not logged in to the [app](https://cs156-s21-team-7pm-4-mapache.herokuapp.com/) before must log in and check if they have Admin privileges by default.