### PR TITLE
7pm-4 kk Add error message when username does not exist for /mapache whois command

### DIFF
--- a/src/main/java/edu/ucsb/mapache/services/WhoIsService.java
+++ b/src/main/java/edu/ucsb/mapache/services/WhoIsService.java
@@ -14,6 +14,9 @@ public class WhoIsService {
   private StudentRepository studentRepository;
   public String getOutput(String username) {
     List<SlackUser> user = slackUserRepository.findByName(username);
+    if(user.size()==0){
+      return "/mapache whois failed: unknown user "+username;
+    }
     SlackUser output = user.get(0);
     String name = output.getProfile().getReal_name();
     String email = output.getProfile().getEmail();

--- a/src/test/java/edu/ucsb/mapache/services/WhoIsServiceTests.java
+++ b/src/test/java/edu/ucsb/mapache/services/WhoIsServiceTests.java
@@ -59,4 +59,17 @@ public class WhoIsServiceTests
         when(mockStudentRepository.findByEmail(email)).thenReturn(students);
         assertEquals(expectedSring, whoIsService.getOutput(username));
     }
+
+    @Test
+    public void test_formatedOutputWhenNoUsernameFound() {
+        String username = "displayname";
+        String email = "email";
+
+        List<SlackUser> slackUsers = new ArrayList<SlackUser>();
+        List<Student> students = new ArrayList<Student>();
+        String expectedSring = "/mapache whois failed: unknown user displayname";
+
+        when(mockSlackUserRepository.findByName(username)).thenReturn(slackUsers);
+        assertEquals(expectedSring, whoIsService.getOutput(username));
+    }
 }


### PR DESCRIPTION
When the user enters /mapache whois usernameThatDoesNotExist, they will receive an error that this username is unknown. 

![image](https://user-images.githubusercontent.com/1119017/120394954-09a66380-c2e9-11eb-850a-826f3b1e9888.png)
