### PR TITLE
7pm-1 eo - hot fix for channel links page path

### DIFF
--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -51,8 +51,8 @@ function App() {
           <AuthorizedRoute path="/member/messages/search" component={SearchResults} authorizedRoles={["admin","member"]} />
           <AuthorizedRoute path="/member/analyzemessages/reactions" exact component={AnalyzeReactions} authorizedRoles={["admin", "member"]} />
           <AuthorizedRoute path="/member/listViewChannels/:channel" component={ChannelPageList} authorizedRoles={["admin","member"]} />
-          <AuthorizedRoute path="/member/channels/:channel" component={ChannelPageScrollable} authorizedRoles={["admin","member"]} />
           <AuthorizedRoute path="/member/channels/:channel/links" component={ChannelPageLinks} authorizedRoles={["admin","member"]} />
+          <AuthorizedRoute path="/member/channels/:channel" component={ChannelPageScrollable} authorizedRoles={["admin","member"]} />
           <AuthorizedRoute path="/member/analyzemessages/reactions" exact component={AnalyzeReactions} authorizedRoles={["admin", "member"]} />
           <AuthorizedRoute path="/member/analyzemessages/countmessages" exact component={CountMessagesByUser} authorizedRoles={["admin", "member"]} />
           <AuthorizedRoute path="/member/analyzemessages/messagehistogram" exact component={HistogramOfMessagesByUser} authorizedRoles={["admin", "member"]} />


### PR DESCRIPTION
In this PR we address a small bug that caused the channel links page to be unviewable, as the path to the page resolved to the scrollable message view instead. 